### PR TITLE
Fix the control bar to the top of the screen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "astoria-ui-test",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/src/index.html
+++ b/src/index.html
@@ -63,7 +63,7 @@
         </div>
     </div>
 </div>
-<table class="table is-striped is-narrow is-hoverable is-fullwidth is-family-monospace">
+<table class="log-table table is-striped is-narrow is-hoverable is-fullwidth is-family-monospace">
     <tbody id="log"></tbody>
 </table>
 

--- a/src/main.js
+++ b/src/main.js
@@ -116,6 +116,7 @@ const handlers = {
     }
 
     $.log.appendChild(entryFragment)
+    contentEl.scrollIntoView()
   },
   'astoria/broadcast/start_button': contents => {
     createPlainLogEntry('▶️ Start button pressed', 'text-d-blue', 'text-bold')

--- a/src/main.js
+++ b/src/main.js
@@ -19,6 +19,13 @@ let connectedServices = {
   'astprocd': false,
 }
 let $ = {}
+let shouldAutoScroll = true
+
+window.addEventListener('scroll', function(e) {
+  shouldAutoScroll = window.scrollY + window.innerHeight >= document.body.scrollHeight
+}, {
+  passive: true,
+})
 
 function updateServiceState() {
   const runningServiceCount = Object.values(connectedServices).filter(val => val).length
@@ -116,7 +123,7 @@ const handlers = {
     }
 
     $.log.appendChild(entryFragment)
-    contentEl.scrollIntoView()
+    if(shouldAutoScroll) contentEl.scrollIntoView()
   },
   'astoria/broadcast/start_button': contents => {
     createPlainLogEntry('▶️ Start button pressed', 'text-d-blue', 'text-bold')

--- a/src/style.scss
+++ b/src/style.scss
@@ -12,7 +12,6 @@ $navbar-breakpoint: 1px;
   position: fixed;
   width: 100%;
   top:0;
-  max-height: 50px;
 
   & > .field {
     margin-bottom: 0;
@@ -20,7 +19,8 @@ $navbar-breakpoint: 1px;
 }
 
 .log-table{
-  margin-top: 50px;
+  // button height + (4px padding * 2) + (1px border * 2)
+  margin-top: calc(2.5em + 8px + 2px);
 }
 
 #status {

--- a/src/style.scss
+++ b/src/style.scss
@@ -2,17 +2,25 @@ $primary: #3270ed;
 $family-sans-serif: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", "Cantarell", "Ubuntu", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
 $navbar-breakpoint: 1px;
 
-@import "node_modules/bulma";
+@import "node_modules/bulma/bulma";
 
 .controls {
   display: flex;
   padding: 4px;
   background: $light;
   border: 1px solid $border-light;
+  position: fixed;
+  width: 100%;
+  top:0;
+  max-height: 50px;
 
   & > .field {
     margin-bottom: 0;
   }
+}
+
+.log-table{
+  margin-top: 50px;
 }
 
 #status {


### PR DESCRIPTION
Also auto scroll when a new log line is added.

As we use `position: fixed` for this we have to manually add margin to the table as the control bar is outside the flow of the document. This does mean we have to hardcode a magic number for the table margin, but by using `calc` and the `em` units used by bulma for the button height we should handle browsers using different font sizes